### PR TITLE
feat: Add calendar event fields to KeyStats

### DIFF
--- a/company_info.proto
+++ b/company_info.proto
@@ -43,6 +43,28 @@ message KeyStats {
     float debtToEquity = 19;
     float freeCashFlow = 20;
     float grossMargin = 21;
+    
+    // Dividend Events
+    string exDividendDate = 22;         // Date stock trades ex-dividend (critical for options pricing)
+    string dividendPaymentDate = 23;    // When dividend is paid to shareholders
+    string dividendDeclarationDate = 24; // When dividend was declared by company
+    
+    // Corporate Actions
+    repeated string stockSplitDates = 25; // Historical and upcoming stock split dates
+    string lastSplitDate = 26;           // Most recent stock split date
+    float lastSplitFactor = 27;          // Split ratio (e.g., 2.0 for 2-for-1 split)
+    
+    // Fiscal Calendar
+    string fiscalYearEnd = 28;           // Company's fiscal year end date
+    string nextReportDate = 29;          // Next quarterly earnings report date
+    
+    // Market Events (optional macro events)
+    repeated string fomcDates = 30;      // Upcoming Federal Reserve FOMC meetings
+    string nextIndexRebalance = 31;      // Next major index rebalancing date (if applicable)
+    
+    // Shareholder Events
+    string nextShareholderMeeting = 32;  // Next annual/special shareholder meeting
+    string lockupExpiration = 33;        // IPO lockup expiration date (if applicable)
 }
 
 message CompanyInfoRequest {

--- a/packages/csharp/ProtoModels.csproj
+++ b/packages/csharp/ProtoModels.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>ProtoModels</PackageId>
-    <PackageVersion>1.3.0</PackageVersion>
+    <PackageVersion>1.4.0</PackageVersion>
     <Authors>Your Name</Authors>
     <Company>Your Company</Company>
     <Description>Generated protobuf models for trading and financial data</Description>

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "proto-models-py"
-version = "1.3.0"
+version = "1.4.0"
 description = "Generated Python protobuf models for trading and financial data"
 readme = "README.md"
 authors = [

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bookerinvestmentgroup/proto-models-ts",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Generated TypeScript protobuf models for trading and financial data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Add dividend event dates (ex-dividend, payment, declaration)
- Add stock split tracking (dates and factors)
- Add fiscal calendar fields (year end, next report)
- Add market events (FOMC dates, index rebalancing)
- Add shareholder events (meetings, lockup expiration)
- Bump version to 1.4.0 across all packages